### PR TITLE
8 - Improved video reading code structure

### DIFF
--- a/src/pattern_tracking/logic/video/AbstractFrameProvider.py
+++ b/src/pattern_tracking/logic/video/AbstractFrameProvider.py
@@ -7,10 +7,10 @@ import numpy as np
 
 class AbstractFrameProvider(ABC):
 
-    def __init__(self, halt_event: Event, max_frames_in_queue: int = 30):
+    def __init__(self, halt_event: Event, is_video: bool, max_frames_in_queue: int = 30):
         self._halt_event = halt_event
         """Event used to check whether or not to continue working"""
-        self._is_video = False
+        self._is_video = is_video
         """True if the feed is a static video, false if it is live"""
         self._frames_queue: Queue[tuple[int, np.ndarray] | None] = Queue(max_frames_in_queue)
         """The queue containing all the frames grabbed by the reader"""
@@ -18,6 +18,10 @@ class AbstractFrameProvider(ABC):
     @abstractmethod
     def start(self):
         """Run this frame provider in the background, to make it acquire frames"""
+        pass
+
+    @abstractmethod
+    def stop(self):
         pass
 
     def grab_frame(self,

--- a/src/pattern_tracking/logic/video/FramesFromDistantServer.py
+++ b/src/pattern_tracking/logic/video/FramesFromDistantServer.py
@@ -7,10 +7,13 @@ from src.pattern_tracking.logic.video.AbstractFrameProvider import AbstractFrame
 class FramesFromDistantServer(AbstractFrameProvider):
     
     def __init__(self, ip_address: str, port: int, halt_event: Event, max_frames_in_queue: int = 30):
-        super().__init__(halt_event, max_frames_in_queue)
+        super().__init__(halt_event, False, max_frames_in_queue)
         self._conn_ended = Event()
         self._client = FrameTCPClient(ip_address, port, halt_event, self._conn_ended)
         self._frames_queue = self._client.received_frames_queue
 
     def start(self):
         self._client.run_forever()
+
+    def stop(self):
+        self._client.force_stop()

--- a/src/pattern_tracking/logic/video/LiveFeedWrapper.py
+++ b/src/pattern_tracking/logic/video/LiveFeedWrapper.py
@@ -1,6 +1,4 @@
-
-from src.pattern_tracking.logic.video.FramesFromDistantServer import FramesFromDistantServer
-from src.pattern_tracking.logic.video.VideoReader import VideoReader
+from src.pattern_tracking.logic.video.AbstractFrameProvider import AbstractFrameProvider
 
 
 class LiveFeedWrapper:
@@ -10,11 +8,14 @@ class LiveFeedWrapper:
     to all child classes who required the live feed
     """
 
-    def __init__(self, feed: VideoReader | FramesFromDistantServer):
+    def __init__(self, feed: AbstractFrameProvider):
         self._feed = feed
 
     def start(self):
         self._feed.start()
+
+    def stop(self):
+        self._feed.stop()
 
     def grab_frame(self, block: bool = True):
         return self._feed.grab_frame(block)
@@ -22,9 +23,7 @@ class LiveFeedWrapper:
     def get_halt_event(self):
         return self._feed.get_halt_event()
 
-    def change_feed(self, feed_origin: str | int, is_video: bool, loop_video: bool = False):
-        self._feed.change_feed(feed_origin, is_video, loop_video)
-
-    def change_feed_to_server(self, feed: FramesFromDistantServer):
+    def change_feed(self, feed: AbstractFrameProvider):
+        self._feed.stop()
         self._feed = feed
         self._feed.start()

--- a/src/pattern_tracking/qt_gui/top_menu_bar/video/SelectCameraAsLiveFeedAction.py
+++ b/src/pattern_tracking/qt_gui/top_menu_bar/video/SelectCameraAsLiveFeedAction.py
@@ -6,7 +6,7 @@ from src.pattern_tracking.shared import utils
 
 
 class SelectCameraAsLiveFeedAction(QAction):
-    
+
     def __init__(self, live_feed: LiveFeedWrapper):
         super().__init__()
         self._live_feed = live_feed
@@ -15,9 +15,6 @@ class SelectCameraAsLiveFeedAction(QAction):
 
     def _set_camera_as_live_feed(self):
         _, working_ports, _ = utils.opencv_list_available_camera_ports()
-        if type(self._live_feed == VideoReader):
-            self._live_feed.change_feed(working_ports[0], is_video=False)
-        else:
-            self._live_feed = VideoReader(working_ports[0],
-                                          halt_work=self._live_feed.get_halt_event(),
-                                          is_video=False)
+        self._live_feed.change_feed(VideoReader(working_ports[0],
+                                                halt_work=self._live_feed.get_halt_event(),
+                                                is_video=False))

--- a/src/pattern_tracking/qt_gui/top_menu_bar/video/SelectFramesFromServerAction.py
+++ b/src/pattern_tracking/qt_gui/top_menu_bar/video/SelectFramesFromServerAction.py
@@ -16,4 +16,4 @@ class SelectFramesFromServerAction(QAction):
         dlg = NewServerFeedQDialog(self._live_feed.get_halt_event())
         if dlg.exec():
             feed = dlg.get_connection_result()
-            self._live_feed.change_feed_to_server(feed)
+            self._live_feed.change_feed(feed)

--- a/src/pattern_tracking/qt_gui/top_menu_bar/video/SelectVideoAction.py
+++ b/src/pattern_tracking/qt_gui/top_menu_bar/video/SelectVideoAction.py
@@ -17,12 +17,11 @@ class SelectVideoAction(QAction):
     def _select_video_dialog(self):
         file_name, _ = QFileDialog.getOpenFileName(self._dialog_parent, "Open video file", filter="Video files (*.avi *.jpg *.mp4)")
         if len(file_name) != 0:
-            if type(self._live_feed == VideoReader):
-                self._live_feed.change_feed(file_name, is_video=True, loop_video=True)
-            else:
-                self._live_feed = VideoReader(file_name,
-                                              halt_work=self._live_feed.get_halt_event(),
-                                              is_video=True, loop_video=True)
+            self._live_feed.change_feed(
+                VideoReader(file_name,
+                            halt_work=self._live_feed.get_halt_event(),
+                            is_video=True, loop_video=True)
+            )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #8 

The legacy code was very confusing and even though it would complete its work properly, modifying it would've been too complicated. Those problems came from the fact that the `VideoReader` class can read a video file and read a live video feed. The same object could also be stopped to change its input (switching from live to a video).

The refactor implemented by this removes this ambiguous usage and re-creates a `VideoReader` whenever the user wishes to switch the input video feed. Structure has been simplified and more made more readable.