### PR TITLE
Use backwards-compatible type hint for communication protocol files

### DIFF
--- a/src/comm_protocol/Packet.py
+++ b/src/comm_protocol/Packet.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import struct
+import typing
 
 import numpy as np
 import fastcrc
@@ -177,7 +178,7 @@ class Packet:
         return Packet(0, PacketType.OK, np.array((), dtype=PacketDataType.U8_INT.value.type_))
 
     @classmethod
-    def deserialize(cls, raw_packet: bytes) -> Packet | None:
+    def deserialize(cls, raw_packet: bytes) -> typing.Union[Packet, None]:
         """Deserializes a packet, and returns a Packet object. Returns None in case of protocol or CRC mismatch"""
 
         # find payload's format in the raw packet

--- a/src/comm_protocol/PacketDataType.py
+++ b/src/comm_protocol/PacketDataType.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import typing
 from enum import Enum
 from typing import Callable
 
@@ -72,9 +73,9 @@ class PacketDataType(Enum):
         return pdtype_value.type_
 
     @classmethod
-    def find(cls, test: Callable[[PacketDataTypeValue], bool]) -> PacketDataTypeValue | None:
+    def find(cls, test: Callable[[PacketDataTypeValue], bool]) -> typing.Union[PacketDataTypeValue, None]:
         finished = False
-        result: type | None = None
+        result: typing.Union[type, None] = None
         generator = enumerate(PacketDataType)
 
         v = next(generator)

--- a/src/comm_protocol/PacketHandler.py
+++ b/src/comm_protocol/PacketHandler.py
@@ -1,6 +1,7 @@
 import logging
 import socket
 import time
+import typing
 
 from src.comm_protocol.Packet import Packet
 
@@ -12,7 +13,7 @@ class PacketHandler:
     """
 
     @staticmethod
-    def read_start_word(request: socket.socket, logger: logging.Logger) -> bytes | None:
+    def read_start_word(request: socket.socket, logger: logging.Logger) -> typing.Union[bytes, None]:
         result = None
         request.setblocking(False)
         try:
@@ -27,7 +28,7 @@ class PacketHandler:
             return result
 
     @staticmethod
-    def read_until_end_word(request: socket.socket, start_time: float, max_timeout_s: int) -> bytes | None:
+    def read_until_end_word(request: socket.socket, start_time: float, max_timeout_s: int) -> typing.Union[bytes, None]:
         data = b""
         # since we already read the start word, we subtract its size to what we have to read
         received = request.recv(Packet.PAYLOAD_LEN_IDX - Packet.LEN_START_MAGIC_WORD)


### PR DESCRIPTION
Multiple type hints (such as `def f(x) -> int | None:`) were not available until Py3.10.  
This PR modifies the files of the communication protocol to use a backwards-compatible type hint when necessary.

Fixes #20 