### PR TITLE
27 raspi release camera on exit

### DIFF
--- a/docs/custom_integrations/tixier_mita_lab/README.md
+++ b/docs/custom_integrations/tixier_mita_lab/README.md
@@ -19,7 +19,10 @@ Transfer both of these to the RaspberryPI and put them in the same folder.
 The final folder structure should look like this :
 
 	|
-	*-- comm_protocol
+	*-- src/
+    |    |
+    |    *-- comm_protocol/
+    |
 	*-- custom_raspberrypi_headless.py
 
 ### Setting up the Ethernet connection

--- a/docs/custom_integrations/tixier_mita_lab/custom_raspberrypi_headless.py
+++ b/docs/custom_integrations/tixier_mita_lab/custom_raspberrypi_headless.py
@@ -21,8 +21,8 @@ import atexit
 import numpy as np
 from picamera import PiCamera
 
-from comm_protocol.server.FrameTCPServer import FrameTCPServer
-from comm_protocol.server.FrameTCPServerRequestHandler import FrameTCPServerRequestHandler
+from src.comm_protocol.server.FrameTCPServer import FrameTCPServer
+from src.comm_protocol.server.FrameTCPServerRequestHandler import FrameTCPServerRequestHandler
 
 global server
 

--- a/docs/custom_integrations/tixier_mita_lab/custom_raspberrypi_headless.py
+++ b/docs/custom_integrations/tixier_mita_lab/custom_raspberrypi_headless.py
@@ -15,7 +15,7 @@
 # WARNING this file code is JUST for camera for the moment
 
 from queue import Queue
-from threading import Thread
+from threading import Thread, Event
 
 import numpy as np
 from picamera import PiCamera


### PR DESCRIPTION
Adds a missing import, a new exit handler that *should* release the RaspberryPi camera when the script is closed, and modified imports from `comm_protocol`.